### PR TITLE
Run DwC mapping with ordered occs

### DIFF
--- a/sql/dwc_occurrence.sql
+++ b/sql/dwc_occurrence.sql
@@ -189,4 +189,5 @@ WHERE
   o."Sporen Waarnemingen Naam" != '2 dode geiten' AND
   o."Sporen Waarnemingen Naam" != 'Andere'
 ORDER BY
-    o."Registratie ID" || ':' || o."species_name_hash" ASC -- occurrenceID
+    o."Registratie ID" ASC, -- eventID
+    o."species_name_hash" ASC -- species hash (part of occurrenceID)


### PR DESCRIPTION
This PR will order DwC occurrences output by `occurrenceID`.
In the future the number of changes will be limited to the real changes, random (?) raw data shuffle will not be reflected in the DwC mapped data.