### PR TITLE
Apply mapping after adding `identificationVerificationStatus` to SQL mapping script

### DIFF
--- a/tests/test_dwc_occurrence.R
+++ b/tests/test_dwc_occurrence.R
@@ -24,6 +24,7 @@ testthat::test_that("Right columns in right order", {
     "recordedBy",
     "individualCount",
     "occurrenceRemarks",
+    "identificationVerificationStatus",
     "eventID",
     "eventDate",
     "locationID",

--- a/tests/test_dwc_occurrence.R
+++ b/tests/test_dwc_occurrence.R
@@ -100,6 +100,20 @@ testthat::test_that("occurrenceRemarks values", {
   )
 })
 
+testthat::test_that("identificationVerificationStatus is always filled in", {
+  testthat::expect_true(all(!is.na(dwc_occurrence$identificationVerificationStatus)))
+})
+
+testthat::test_that("identificationVerificationStatus is always 'verified'", {
+  testthat::expect_equal(
+    dwc_occurrence %>%
+      dplyr::distinct(identificationVerificationStatus) %>%
+      arrange(identificationVerificationStatus) %>%
+      pull(),
+    "verified"
+  )
+})
+
 testthat::test_that("eventID is always filled in", {
   testthat::expect_true(all(!is.na(dwc_occurrence$eventID)))
 })


### PR DESCRIPTION
As expected all `occurrence.csv` is rewritten (41,470 additions, 41,470 deletions) as one field has been added to all data.