### PR TITLE
Alopochen aegyptiaca

### DIFF
--- a/sql/dwc_occurrence.sql
+++ b/sql/dwc_occurrence.sql
@@ -139,7 +139,7 @@ SELECT
     WHEN o."Sporen Waarnemingen Naam" = 'Wolhandkrab' THEN 'Eriocheir sinensis'
     WHEN o."Sporen Waarnemingen Naam" = 'Nijlgans' THEN 'Alopochen aegyptiaca'
     WHEN o."Sporen Waarnemingen Naam" = 'Nijlganzen' THEN 'Alopochen aegyptiaca'
-    WHEN o."Sporen Waarnemingen Naam" = 'Nijlganzen nest' THEN 'Alopochen aegyptiacus'
+    WHEN o."Sporen Waarnemingen Naam" = 'Nijlganzen nest' THEN 'Alopochen aegyptiaca'
     WHEN o."Sporen Waarnemingen Naam" = 'Pootafdrukken wasbeer' THEN 'Procyon lotor'
     WHEN o."Sporen Waarnemingen Naam" = 'Geelbuikschildpad' THEN 'Trachemys scripta scripta'
     WHEN o."Sporen Waarnemingen Naam" = 'Geelwangwaterschildpadden' THEN 'Trachemys scripta troosti'

--- a/sql/dwc_occurrence.sql
+++ b/sql/dwc_occurrence.sql
@@ -137,8 +137,8 @@ SELECT
     WHEN o."Sporen Waarnemingen Naam" = 'waterschildpad' THEN 'Emydidae'
     WHEN o."Sporen Waarnemingen Naam" = 'Castor fiber' THEN 'Castor fiber' -- Castor fiber unchanged
     WHEN o."Sporen Waarnemingen Naam" = 'Wolhandkrab' THEN 'Eriocheir sinensis'
-    WHEN o."Sporen Waarnemingen Naam" = 'Nijlgans' THEN 'Alopochen aegyptiacus'
-    WHEN o."Sporen Waarnemingen Naam" = 'Nijlganzen' THEN 'Alopochen aegyptiacus'
+    WHEN o."Sporen Waarnemingen Naam" = 'Nijlgans' THEN 'Alopochen aegyptiaca'
+    WHEN o."Sporen Waarnemingen Naam" = 'Nijlganzen' THEN 'Alopochen aegyptiaca'
     WHEN o."Sporen Waarnemingen Naam" = 'Nijlganzen nest' THEN 'Alopochen aegyptiacus'
     WHEN o."Sporen Waarnemingen Naam" = 'Pootafdrukken wasbeer' THEN 'Procyon lotor'
     WHEN o."Sporen Waarnemingen Naam" = 'Geelbuikschildpad' THEN 'Trachemys scripta scripta'

--- a/tests/test_dwc_occurrence.R
+++ b/tests/test_dwc_occurrence.R
@@ -199,7 +199,7 @@ testthat::test_that("scientificName is never NA and one of the list", {
     "Psittacula krameri",
     "Emydidae",
     "Eriocheir sinensis",
-    "Alopochen aegyptiacus",
+    "Alopochen aegyptiaca",
     "Procyon lotor",
     "Trachemys scripta scripta",
     "Dendrocygna bicolor",


### PR DESCRIPTION
This pull request primarily addresses a taxonomic correction in the scientific name of the Egyptian goose (`Alopochen aegyptiaca`) across the mapping (SQL script), corresponding DwC csv output and the tests.


* **SQL Query Update**:
  - Updated the mapping for `'Nijlgans'`, `'Nijlganzen'`, and `'Nijlganzen nest'` to reflect the corrected scientific name `Alopochen aegyptiaca` in the `sql/dwc_occurrence.sql` file.

* **Test Case Update**:
  - Modified the test in `tests/test_dwc_occurrence.R` to use the corrected scientific name `Alopochen aegyptiaca` in the validation list.