### PR TITLE
Update action tag: avoid using tag master

### DIFF
--- a/.github/workflows/fetch-data.yaml
+++ b/.github/workflows/fetch-data.yaml
@@ -63,7 +63,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@master
+        uses: devops-infra/action-commit-push@v1.2.0
         with:
           github_token: ${{ secrets.WORKFLOWS }}
           commit_prefix: "[AUTO]"

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ src/*.pdf
 
 # Pictures
 data/raw/pictures/*
+.positai


### PR DESCRIPTION
This gave problem as the master is pointing to v1.2.1 which is not still available.