### PR TITLE
Fix #87

### DIFF
--- a/.github/workflows/update-data.yaml
+++ b/.github/workflows/update-data.yaml
@@ -56,14 +56,20 @@ jobs:
           source("src/install_packages.R")
         shell: Rscript {0}
 
-      - name: Fetch data
+      - name: Fetch data via WebDAV
         id: fetch_data
+        env:
+          WEBDAV_PASSWORD: ${{ secrets.WEBDAV_PASSWORD }}
         run: |
-          source("src/run_fetch_data.R")
-        shell: Rscript {0}
+          curl --fail -u "INBO:${WEBDAV_PASSWORD}" \
+            "https://int-web.vmm.be/ratten/Dieren%20en%20Planten%20Waarnemingen%20INBO%20Email-nl-be.csv" \
+            -o "data/raw/Dieren en Planten Waarnemingen from 2022-01-01.csv"
+          curl --fail -u "INBO:${WEBDAV_PASSWORD}" \
+            "https://int-web.vmm.be/ratten/Vangsten%20INBO%20Email-nl-be.csv" \
+            -o "data/raw/Vangsten from 2022-01-01.csv"
         continue-on-error: true
 
-      - name: Create issue if fetch data fails
+      - name: Create issue if fetch fails
         if: steps.fetch_data.outcome == 'failure'
         uses: actions/github-script@v9
         with:
@@ -73,13 +79,37 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: '[AUTO] Data fetch failed',
-              body: `This is an automated issue.\n\nThe data fetching step failed in the workflow run.\n\nFailed run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              labels: ['automated workflow', 'fetch']
+              body: `This is an automated issue.\n\nThe WebDAV data fetch step failed in the workflow run.\n\nFailed run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              labels: ['automated workflow', 'fetching']
             })
             core.setFailed('Data fetch failed')
 
-      - name: Check for fetched data changes
-        id: fetch_changes
+      - name: Read data
+        if: steps.fetch_data.outcome == 'success'
+        id: read_data
+        run: |
+          source("src/run_read_data.R")
+        shell: Rscript {0}
+        continue-on-error: true
+
+      - name: Create issue if read data fails
+        if: steps.read_data.outcome == 'failure'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '[AUTO] Data reading failed',
+              body: `This is an automated issue.\n\nThe data reading step failed in the workflow run.\n\nFailed run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              labels: ['automated workflow', 'reading']
+            })
+            core.setFailed('Data reading failed')
+
+      - name: Check for read data changes
+        if: steps.fetch_data.outcome == 'success' && steps.read_data.outcome == 'success'
+        id: read_changes
         run: |
           if git status --porcelain | grep -q .; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -89,7 +119,7 @@ jobs:
           fi
 
       - name: Mapping to DwC
-        if: steps.fetch_changes.outputs.has_changes == 'true'
+        if: steps.read_changes.outputs.has_changes == 'true'
         id: dwc_mapping
         run: |
           source("src/run_dwc_mapping.R")
@@ -112,7 +142,7 @@ jobs:
             core.setFailed('DwC mapping failed')
 
       - name: Run tests
-        if: steps.fetch_changes.outputs.has_changes == 'true'
+        if: steps.read_changes.outputs.has_changes == 'true'
         id: run_tests
         run: |
           testthat::test_file("tests/test_dwc_occurrence.R", reporter = "stop")
@@ -135,7 +165,7 @@ jobs:
             core.setFailed('Tests failed')
 
       - name: Commit and push all changes
-        if: steps.fetch_changes.outputs.has_changes == 'true' && steps.run_tests.outcome == 'success'
+        if: steps.read_changes.outputs.has_changes == 'true' && steps.run_tests.outcome == 'success'
         uses: devops-infra/action-commit-push@f066ea8e19660de57d3d3a4a0b9d294ea2612e20 # v1.5.0
         with:
           github_token: ${{ github.token }}
@@ -145,13 +175,13 @@ jobs:
           add_timestamp: true
 
       - name: Get branch name
-        if: steps.fetch_changes.outputs.has_changes == 'true' && steps.run_tests.outcome == 'success'
+        if: steps.read_changes.outputs.has_changes == 'true' && steps.run_tests.outcome == 'success'
         id: branch_name
         run: |
           echo "name=$(git branch --show-current)" >> "$GITHUB_OUTPUT"
 
       - name: Create PR, add labels and merge
-        if: steps.fetch_changes.outputs.has_changes == 'true' && steps.run_tests.outcome == 'success'
+        if: steps.read_changes.outputs.has_changes == 'true' && steps.run_tests.outcome == 'success'
         uses: actions/github-script@v9
         with:
           github-token: ${{ github.token }}

--- a/src/read_data.Rmd
+++ b/src/read_data.Rmd
@@ -34,7 +34,7 @@ library(digest)         # To generate hashes
 
 # Fetch raw data
 
-The source data are provided manually and stored in `data/raw`. If this workflow can be fully automated, replace with querying from VMM endpoints.
+The source data are provided via WebDAV and stored in `data/raw`. If this workflow can be fully automated, replace with querying from VMM endpoints.
 
 ## Fetch observations
 

--- a/src/run_read_data.R
+++ b/src/run_read_data.R
@@ -10,6 +10,6 @@ library(knitr)
 
 # create temporary R file
 tempR <- tempfile(fileext = ".R")
-knitr::purl("./src/fetch_data.Rmd", output=tempR)
+knitr::purl("./src/read_data.Rmd", output=tempR)
 source(tempR)
 unlink(tempR)


### PR DESCRIPTION
This pull request updates the data fetching workflow to use WebDAV for retrieving source data. The changes also update related scripts and documentation to reflect the new process. The previously called "fetch" is actually a "read".

**Fetching data automatically:**

* The workflow in `.github/workflows/update-data.yaml` now fetches data via WebDAV using `curl` with credentials. If fetching fails, an automated issue is created with updated labels and messaging. [[1]](diffhunk://#diff-ba3508df13855ec03c4b51f81449b02fff301eed7e3cd7b57d0fcd7f015f4e89L59-R72) [[2]](diffhunk://#diff-ba3508df13855ec03c4b51f81449b02fff301eed7e3cd7b57d0fcd7f015f4e89L76-R112)
* The workflow renames the previously "Fetch data" step to "Read data" step (running `src/run_read_data.R`, previously called `src/run_fetch_data.R`).
* Downstream steps (DwC mapping, tests, commit/push, PR creation) are updated to depend on both successful fetch and read steps, using new output variables and step IDs for better control.

**Script and documentation updates:**

* The R Markdown file `src/fetch_data.Rmd` is renamed to `src/read_data.Rmd`, and its documentation is updated to describe the new WebDAV-based data source.
* The R script `src/run_fetch_data.R` is renamed to `src/run_read_data.R` and updated to reference the new Rmd filename.