### PR TITLE
Analyse the test results to identify failures

### DIFF
--- a/.github/workflows/update-data.yaml
+++ b/.github/workflows/update-data.yaml
@@ -145,7 +145,13 @@ jobs:
         if: steps.read_changes.outputs.has_changes == 'true'
         id: run_tests
         run: |
-          testthat::test_file("tests/test_dwc_occurrence.R", reporter = "stop")
+          results <- testthat::test_file("tests/test_dwc_occurrence.R")
+          df <- as.data.frame(results)
+          n_failures <- sum(df$failed) + sum(df$error)
+          if (n_failures > 0) {
+            message(sprintf("%d test(s) failed or errored.", n_failures))
+            quit(status = 1, save = "no")
+          }
         shell: Rscript {0}
         continue-on-error: true
 


### PR DESCRIPTION
This PR should fix #342. We need to merge to `main` to test actually if it's true. The idea is to catch the test results as data.frame and check values in columns `errors` and `failures`. Based on that, trigger a `quit()` which is interpreted as step failure.